### PR TITLE
Add missing <cstdint> include for uint64_t in MC.h

### DIFF
--- a/MC.h
+++ b/MC.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cmath>
+#include <cstdint>
 
 namespace MC
 {


### PR DESCRIPTION
GCC 13+ no longer implicitly includes <cstdint> through other standard headers, causing compilation failure on newer toolchains.
fix #6 