### PR TITLE
Add license file with MIT and Unlicense

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,54 @@
+This software is dual-licensed under the Public Domain and the MIT License.
+You may choose the license that best fits your needs.
+
+------------------------------------------------------------------------------
+OPTION 1: PUBLIC DOMAIN (Unlicense)
+------------------------------------------------------------------------------
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org/>
+
+
+------------------------------------------------------------------------------
+OPTION 2: MIT LICENSE
+------------------------------------------------------------------------------
+
+Copyright (c) 2026 aparis69
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the " Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Greetings! 

During the review of the PR https://github.com/conan-io/conan-center-index/pull/29586/ in Conan Center Index, to package MatchingCubeCpp there, I noted that there is no license file in this project, only a footnote about the license on the README.

It would be great to have a license copy file to package with the project as well, so users can understand better what specific license this project is using, as both MIT and Public Domain have several flavors with different details.

For this PR, I just copied the content of:

- https://spdx.org/licenses/Unlicense.html
- https://spdx.org/licenses/MIT.html

And added the year and the author's name. No customization was made.

Regards! 